### PR TITLE
Jellis/path converting fs

### DIFF
--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
@@ -109,12 +109,10 @@ public final class PathConvertingFileSystem extends FileSystem {
         return delegate.mkdirs(toDelegatePath(f), permission);
     }
 
-    // convenience
     private Path toDelegatePath(Path path) {
         return toDelegatePathFunc.apply(path);
     }
 
-    // convenience
     private Path toReturnPath(Path path) {
         return toReturnPathFunc.apply(path);
     }

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
@@ -29,8 +29,9 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 
 /**
- * A decorator {@link FileSystem} that converts input paths using {@code toDelegateUri} and returned paths to {@code
- * fromScheme}.
+ * A decorator {@link FileSystem} that delegates calls and converts paths to/from the delegate FileSystem.
+ * {@link Path}s passed into methods are converted using {@code toDelegatePathFunc} before being forwarded.
+ * {@link Path}s returned from the delegate are converted using {@code toReturnPathFunc} before being returned.
  */
 public final class PathConvertingFileSystem extends FileSystem {
 
@@ -47,33 +48,15 @@ public final class PathConvertingFileSystem extends FileSystem {
         super.setConf(delegate.getConf());
     }
 
+    // convenience
     private Path toDelegatePath(Path path) {
         return toDelegatePathFunc.apply(path);
     }
 
+    // convenience
     private Path toReturnPath(Path path) {
         return toReturnPathFunc.apply(path);
     }
-
-    /*
-    private Path toDelegatePath(Path path) {
-        return new Path(toDelegateUri.apply(path.toUri()));
-    }
-
-    private Path toReturnPath(Path path) {
-        return new Path(toReturnUri.apply(path.toUri()));
-    }
-
-    private URI swapSchemeUri(URI uri, String swapScheme) {
-        if (uri.getScheme() != null) {
-            return UriBuilder.fromUri(uri)
-                    .scheme(swapScheme)
-                    .build();
-        } else {
-            return uri;
-        }
-    }
-    */
 
     @Override
     public URI getUri() {

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
@@ -42,10 +42,10 @@ public final class PathConvertingFileSystem extends FileSystem {
     public PathConvertingFileSystem(FileSystem delegate,
             Function<Path, Path> toDelegatePathFunc,
             Function<Path, Path> toReturnPathFunc) {
+        super.setConf(delegate.getConf());
         this.delegate = delegate;
         this.toDelegatePathFunc = toDelegatePathFunc;
         this.toReturnPathFunc = toReturnPathFunc;
-        super.setConf(delegate.getConf());
     }
 
     @Override
@@ -54,20 +54,20 @@ public final class PathConvertingFileSystem extends FileSystem {
     }
 
     @Override
-    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-        return delegate.open(toDelegatePath(f), bufferSize);
+    public FSDataInputStream open(Path path, int bufferSize) throws IOException {
+        return delegate.open(toDelegatePath(path), bufferSize);
     }
 
     @Override
-    public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize,
+    public FSDataOutputStream create(Path path, FsPermission permission, boolean overwrite, int bufferSize,
             short replication, long blockSize, Progressable progress) throws IOException {
-        return delegate.create(toDelegatePath(f), permission, overwrite, bufferSize, replication, blockSize,
+        return delegate.create(toDelegatePath(path), permission, overwrite, bufferSize, replication, blockSize,
                 progress);
     }
 
     @Override
-    public FSDataOutputStream append(Path f, int bufferSize, Progressable progress) throws IOException {
-        return delegate.append(toDelegatePath(f), bufferSize, progress);
+    public FSDataOutputStream append(Path path, int bufferSize, Progressable progress) throws IOException {
+        return delegate.append(toDelegatePath(path), bufferSize, progress);
     }
 
     @Override
@@ -76,13 +76,13 @@ public final class PathConvertingFileSystem extends FileSystem {
     }
 
     @Override
-    public boolean delete(Path f, boolean recursive) throws IOException {
-        return delegate.delete(toDelegatePath(f), recursive);
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        return delegate.delete(toDelegatePath(path), recursive);
     }
 
     @Override
-    public FileStatus[] listStatus(Path f) throws FileNotFoundException, IOException {
-        FileStatus[] fileStatuses = delegate.listStatus(toDelegatePath(f));
+    public FileStatus[] listStatus(Path path) throws FileNotFoundException, IOException {
+        FileStatus[] fileStatuses = delegate.listStatus(toDelegatePath(path));
         for (int i = 0; i < fileStatuses.length; i++) {
             fileStatuses[i] = toReturnFileStatus(fileStatuses[i]);
         }
@@ -90,13 +90,13 @@ public final class PathConvertingFileSystem extends FileSystem {
     }
 
     @Override
-    public FileStatus getFileStatus(Path f) throws IOException {
-        return toReturnFileStatus(delegate.getFileStatus(toDelegatePath(f)));
+    public FileStatus getFileStatus(Path path) throws IOException {
+        return toReturnFileStatus(delegate.getFileStatus(toDelegatePath(path)));
     }
 
     @Override
-    public void setWorkingDirectory(Path new_dir) {
-        delegate.setWorkingDirectory(toDelegatePath(new_dir));
+    public void setWorkingDirectory(Path path) {
+        delegate.setWorkingDirectory(toDelegatePath(path));
     }
 
     @Override
@@ -105,8 +105,8 @@ public final class PathConvertingFileSystem extends FileSystem {
     }
 
     @Override
-    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
-        return delegate.mkdirs(toDelegatePath(f), permission);
+    public boolean mkdirs(Path path, FsPermission permission) throws IOException {
+        return delegate.mkdirs(toDelegatePath(path), permission);
     }
 
     private Path toDelegatePath(Path path) {
@@ -129,7 +129,7 @@ public final class PathConvertingFileSystem extends FileSystem {
                 status.getPermission(),
                 status.getOwner(),
                 status.getGroup(),
-                (status.isSymlink() ? status.getSymlink() : null), // getSymlink throws if file is not a symlink
+                status.isSymlink() ? status.getSymlink() : null, // getSymlink throws if file is not a symlink
                 toReturnPath(status.getPath()));
     }
 

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
@@ -48,16 +48,6 @@ public final class PathConvertingFileSystem extends FileSystem {
         super.setConf(delegate.getConf());
     }
 
-    // convenience
-    private Path toDelegatePath(Path path) {
-        return toDelegatePathFunc.apply(path);
-    }
-
-    // convenience
-    private Path toReturnPath(Path path) {
-        return toReturnPathFunc.apply(path);
-    }
-
     @Override
     public URI getUri() {
         return delegate.getUri();
@@ -104,6 +94,31 @@ public final class PathConvertingFileSystem extends FileSystem {
         return toReturnFileStatus(delegate.getFileStatus(toDelegatePath(f)));
     }
 
+    @Override
+    public void setWorkingDirectory(Path new_dir) {
+        delegate.setWorkingDirectory(toDelegatePath(new_dir));
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return toReturnPath(delegate.getWorkingDirectory());
+    }
+
+    @Override
+    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+        return delegate.mkdirs(toDelegatePath(f), permission);
+    }
+
+    // convenience
+    private Path toDelegatePath(Path path) {
+        return toDelegatePathFunc.apply(path);
+    }
+
+    // convenience
+    private Path toReturnPath(Path path) {
+        return toReturnPathFunc.apply(path);
+    }
+
     private FileStatus toReturnFileStatus(FileStatus status) throws IOException {
         // same as FileStatus copy constructor
         return new FileStatus(
@@ -118,21 +133,6 @@ public final class PathConvertingFileSystem extends FileSystem {
                 status.getGroup(),
                 (status.isSymlink() ? status.getSymlink() : null), // getSymlink throws if file is not a symlink
                 toReturnPath(status.getPath()));
-    }
-
-    @Override
-    public void setWorkingDirectory(Path new_dir) {
-        delegate.setWorkingDirectory(toDelegatePath(new_dir));
-    }
-
-    @Override
-    public Path getWorkingDirectory() {
-        return toReturnPath(delegate.getWorkingDirectory());
-    }
-
-    @Override
-    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
-        return delegate.mkdirs(toDelegatePath(f), permission);
     }
 
 }

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/PathConvertingFileSystem.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.hadoop;
+
+import com.google.common.base.Function;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+
+/**
+ * A decorator {@link FileSystem} that converts input paths using {@code toDelegateUri} and returned paths to {@code
+ * fromScheme}.
+ */
+public final class PathConvertingFileSystem extends FileSystem {
+
+    private final FileSystem delegate;
+    private final Function<Path, Path> toDelegatePathFunc;
+    private final Function<Path, Path> toReturnPathFunc;
+
+    public PathConvertingFileSystem(FileSystem delegate,
+            Function<Path, Path> toDelegatePathFunc,
+            Function<Path, Path> toReturnPathFunc) {
+        this.delegate = delegate;
+        this.toDelegatePathFunc = toDelegatePathFunc;
+        this.toReturnPathFunc = toReturnPathFunc;
+        super.setConf(delegate.getConf());
+    }
+
+    private Path toDelegatePath(Path path) {
+        return toDelegatePathFunc.apply(path);
+    }
+
+    private Path toReturnPath(Path path) {
+        return toReturnPathFunc.apply(path);
+    }
+
+    /*
+    private Path toDelegatePath(Path path) {
+        return new Path(toDelegateUri.apply(path.toUri()));
+    }
+
+    private Path toReturnPath(Path path) {
+        return new Path(toReturnUri.apply(path.toUri()));
+    }
+
+    private URI swapSchemeUri(URI uri, String swapScheme) {
+        if (uri.getScheme() != null) {
+            return UriBuilder.fromUri(uri)
+                    .scheme(swapScheme)
+                    .build();
+        } else {
+            return uri;
+        }
+    }
+    */
+
+    @Override
+    public URI getUri() {
+        return delegate.getUri();
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+        return delegate.open(toDelegatePath(f), bufferSize);
+    }
+
+    @Override
+    public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize,
+            short replication, long blockSize, Progressable progress) throws IOException {
+        return delegate.create(toDelegatePath(f), permission, overwrite, bufferSize, replication, blockSize,
+                progress);
+    }
+
+    @Override
+    public FSDataOutputStream append(Path f, int bufferSize, Progressable progress) throws IOException {
+        return delegate.append(toDelegatePath(f), bufferSize, progress);
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        return delegate.rename(toDelegatePath(src), toDelegatePath(dst));
+    }
+
+    @Override
+    public boolean delete(Path f, boolean recursive) throws IOException {
+        return delegate.delete(toDelegatePath(f), recursive);
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path f) throws FileNotFoundException, IOException {
+        FileStatus[] fileStatuses = delegate.listStatus(toDelegatePath(f));
+        for (int i = 0; i < fileStatuses.length; i++) {
+            fileStatuses[i] = toReturnFileStatus(fileStatuses[i]);
+        }
+        return fileStatuses;
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path f) throws IOException {
+        return toReturnFileStatus(delegate.getFileStatus(toDelegatePath(f)));
+    }
+
+    private FileStatus toReturnFileStatus(FileStatus status) throws IOException {
+        // same as FileStatus copy constructor
+        return new FileStatus(
+                status.getLen(),
+                status.isDirectory(),
+                status.getReplication(),
+                status.getBlockSize(),
+                status.getModificationTime(),
+                status.getAccessTime(),
+                status.getPermission(),
+                status.getOwner(),
+                status.getGroup(),
+                (status.isSymlink() ? status.getSymlink() : null), // getSymlink throws if file is not a symlink
+                toReturnPath(status.getPath()));
+    }
+
+    @Override
+    public void setWorkingDirectory(Path new_dir) {
+        delegate.setWorkingDirectory(toDelegatePath(new_dir));
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return toReturnPath(delegate.getWorkingDirectory());
+    }
+
+    @Override
+    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+        return delegate.mkdirs(toDelegatePath(f), permission);
+    }
+
+}

--- a/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
@@ -39,7 +39,7 @@ public class PathConvertingFileSystemTest {
     private static final Path PATH = new Path("/dummy/path");
     private static final Path DELEGATE_PATH = new Path("/delagate/path");
     private static final Path RETURN_PATH = new Path("/return/path");
-    private static final URI DUMMY_URI = URI.create("dummy/uri");
+    private static final URI DUMMY_URI = URI.create("/dummy/uri");
 
     private FileSystem delegate;
     private FSDataInputStream inputStream;
@@ -51,7 +51,7 @@ public class PathConvertingFileSystemTest {
         delegate = mock(FileSystem.class);
         inputStream = mock(FSDataInputStream.class);
         outputStream = mock(FSDataOutputStream.class);
-        convertingFs =  new PathConvertingFileSystem(delegate, DELEGATE_PATH_FUNC.INSTANCE, RETURN_PATH_FUNC.INSTANCE);
+        convertingFs = new PathConvertingFileSystem(delegate, DELEGATE_PATH_FUNC.INSTANCE, RETURN_PATH_FUNC.INSTANCE);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class PathConvertingFileSystemTest {
 
     @Test
     public void listStatus() throws Exception {
-        when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] { fileStatus(DELEGATE_PATH) });
+        when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] {fileStatus(DELEGATE_PATH)});
         FileStatus[] fileStatuses = convertingFs.listStatus(PATH);
 
         assertThat(Arrays.asList(fileStatuses), contains(fileStatus(RETURN_PATH)));

--- a/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
@@ -46,6 +46,24 @@ public final class PathConvertingFileSystemTest {
     private FSDataOutputStream outputStream;
     private PathConvertingFileSystem convertingFs;
 
+    private enum DelegatePathFunc implements Function<Path, Path> {
+        INSTANCE;
+
+        @Override
+        public Path apply(Path input) {
+            return DELEGATE_PATH;
+        }
+    }
+
+    private enum ReturnPathFunc implements Function<Path, Path> {
+        INSTANCE;
+
+        @Override
+        public Path apply(Path input) {
+            return RETURN_PATH;
+        }
+    }
+
     @Before
     public void before() {
         delegate = mock(FileSystem.class);
@@ -142,24 +160,6 @@ public final class PathConvertingFileSystemTest {
 
     private static FileStatus fileStatus(Path path) {
         return new FileStatus(0, false, 0, 0, 0, path);
-    }
-
-    private enum DelegatePathFunc implements Function<Path, Path> {
-        INSTANCE;
-
-        @Override
-        public Path apply(Path input) {
-            return DELEGATE_PATH;
-        }
-    }
-
-    private enum ReturnPathFunc implements Function<Path, Path> {
-        INSTANCE;
-
-        @Override
-        public Path apply(Path input) {
-            return RETURN_PATH;
-        }
     }
 
 }

--- a/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.hadoop;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Function;
+import java.net.URI;
+import java.util.Arrays;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PathConvertingFileSystemTest {
+
+    private static final Path PATH = new Path("/dummy/path");
+    private static final Path DELEGATE_PATH = new Path("/delagate/path");
+    private static final Path RETURN_PATH = new Path("/return/path");
+    private static final URI DUMMY_URI = URI.create("dummy/uri");
+
+    private FileSystem delegate;
+    private FSDataInputStream inputStream;
+    private FSDataOutputStream outputStream;
+    private PathConvertingFileSystem convertingFs;
+
+    @Before
+    public void before() {
+        delegate = mock(FileSystem.class);
+        inputStream = mock(FSDataInputStream.class);
+        outputStream = mock(FSDataOutputStream.class);
+        convertingFs =  new PathConvertingFileSystem(delegate, DELEGATE_PATH_FUNC.INSTANCE, RETURN_PATH_FUNC.INSTANCE);
+    }
+
+    @Test
+    public void getUri() throws Exception {
+        when(delegate.getUri()).thenReturn(DUMMY_URI);
+        URI actualUri = convertingFs.getUri();
+
+        assertThat(actualUri, is(DUMMY_URI));
+    }
+
+    @Test
+    public void open() throws Exception {
+        when(delegate.open(DELEGATE_PATH, 0)).thenReturn(inputStream);
+        FSDataInputStream actualStream = convertingFs.open(PATH, 0);
+
+        assertThat(actualStream, is(inputStream));
+    }
+
+    @Test
+    public void create() throws Exception {
+        when(delegate.create(DELEGATE_PATH, null, false, 0, (short) 0, 0, null)).thenReturn(outputStream);
+        FSDataOutputStream actualStream = convertingFs.create(PATH, null, false, 0, (short) 0, 0, null);
+
+        assertThat(actualStream, is(outputStream));
+    }
+
+    @Test
+    public void append() throws Exception {
+        when(delegate.append(DELEGATE_PATH, 0, null)).thenReturn(outputStream);
+        FSDataOutputStream actualStream = convertingFs.append(PATH, 0, null);
+
+        assertThat(actualStream, is(outputStream));
+    }
+
+    @Test
+    public void rename() throws Exception {
+        when(delegate.rename(DELEGATE_PATH, DELEGATE_PATH)).thenReturn(false);
+        boolean success = convertingFs.rename(PATH, PATH);
+
+        assertThat(success, is(false));
+    }
+
+    @Test
+    public void delete() throws Exception {
+        when(delegate.delete(DELEGATE_PATH, false)).thenReturn(false);
+        boolean success = convertingFs.delete(PATH, false);
+
+        assertThat(success, is(false));
+    }
+
+    @Test
+    public void listStatus() throws Exception {
+        when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] { fileStatus(DELEGATE_PATH) });
+        FileStatus[] fileStatuses = convertingFs.listStatus(PATH);
+
+        assertThat(Arrays.asList(fileStatuses), contains(fileStatus(RETURN_PATH)));
+    }
+
+    @Test
+    public void getFileStatus() throws Exception {
+        when(delegate.getFileStatus(DELEGATE_PATH)).thenReturn(fileStatus(DELEGATE_PATH));
+        FileStatus fileStatus = convertingFs.getFileStatus(PATH);
+
+        assertThat(fileStatus, is(fileStatus(RETURN_PATH)));
+    }
+
+    @Test
+    public void setWorkingDirectory() throws Exception {
+        convertingFs.setWorkingDirectory(PATH);
+        verify(delegate).setWorkingDirectory(DELEGATE_PATH);
+    }
+
+    @Test
+    public void getWorkingDirectory() throws Exception {
+        when(delegate.getWorkingDirectory()).thenReturn(DELEGATE_PATH);
+        Path workingDirectory = convertingFs.getWorkingDirectory();
+
+        assertThat(workingDirectory, is(RETURN_PATH));
+    }
+
+    @Test
+    public void mkdirs() throws Exception {
+        when(delegate.mkdirs(DELEGATE_PATH, null)).thenReturn(false);
+        boolean success = convertingFs.mkdirs(PATH, null);
+
+        assertThat(success, is(false));
+    }
+
+    private static FileStatus fileStatus(Path path) {
+        return new FileStatus(0, false, 0, 0, 0, path);
+    }
+
+    private enum DELEGATE_PATH_FUNC implements Function<Path, Path> {
+        INSTANCE;
+
+        @Override
+        public Path apply(Path input) {
+            return DELEGATE_PATH;
+        }
+    }
+
+    private enum RETURN_PATH_FUNC implements Function<Path, Path> {
+        INSTANCE;
+
+        @Override
+        public Path apply(Path input) {
+            return RETURN_PATH;
+        }
+    }
+
+}

--- a/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/hadoop/PathConvertingFileSystemTest.java
@@ -17,7 +17,7 @@
 package com.palantir.hadoop;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PathConvertingFileSystemTest {
+public final class PathConvertingFileSystemTest {
 
     private static final Path PATH = new Path("/dummy/path");
     private static final Path DELEGATE_PATH = new Path("/delagate/path");
@@ -51,7 +51,7 @@ public class PathConvertingFileSystemTest {
         delegate = mock(FileSystem.class);
         inputStream = mock(FSDataInputStream.class);
         outputStream = mock(FSDataOutputStream.class);
-        convertingFs = new PathConvertingFileSystem(delegate, DELEGATE_PATH_FUNC.INSTANCE, RETURN_PATH_FUNC.INSTANCE);
+        convertingFs = new PathConvertingFileSystem(delegate, DelegatePathFunc.INSTANCE, ReturnPathFunc.INSTANCE);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class PathConvertingFileSystemTest {
         return new FileStatus(0, false, 0, 0, 0, path);
     }
 
-    private enum DELEGATE_PATH_FUNC implements Function<Path, Path> {
+    private enum DelegatePathFunc implements Function<Path, Path> {
         INSTANCE;
 
         @Override
@@ -153,7 +153,7 @@ public class PathConvertingFileSystemTest {
         }
     }
 
-    private enum RETURN_PATH_FUNC implements Function<Path, Path> {
+    private enum ReturnPathFunc implements Function<Path, Path> {
         INSTANCE;
 
         @Override


### PR DESCRIPTION
@uschi2000 @markelliot need this for the `efs` -> `{hdfs,s3a,...}` scheme conversions.

Note: This only implements the required `FileSystem` methods and not every method, which means some of the methods implemented by the underlying `FileSystem` won't work.
