### PR TITLE
Override InputStream#read(byte[], int, int) for performance

### DIFF
--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
@@ -100,7 +100,6 @@ public final class FsCipherInputStream extends FSInputStream {
         }
     }
 
-    // NOTE(jellis): may want to implement the other read methods depending on performance
     @Override
     public int read() throws IOException {
         int bytesRead = decryptedStream.read();

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
@@ -122,5 +122,6 @@ public final class FsCipherInputStream extends FSInputStream {
     @Override
     public void close() throws IOException {
         delegate.close();
+        decryptedStream.close();
     }
 }

--- a/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
+++ b/hadoop-crypto/src/main/java/com/palantir/hadoop/cipher/FsCipherInputStream.java
@@ -103,11 +103,20 @@ public final class FsCipherInputStream extends FSInputStream {
     // NOTE(jellis): may want to implement the other read methods depending on performance
     @Override
     public int read() throws IOException {
-        int ret = decryptedStream.read();
-        if (ret != -1) {
+        int bytesRead = decryptedStream.read();
+        if (bytesRead != -1) {
             decryptedStreamPos++;
         }
-        return ret;
+        return bytesRead;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+        int bytesRead = decryptedStream.read(buffer, offset, length);
+        if (bytesRead != -1) {
+            decryptedStreamPos += bytesRead;
+        }
+        return bytesRead;
     }
 
     @Override

--- a/hadoop-crypto/src/test/java/com/palantir/hadoop/EncryptedFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/hadoop/EncryptedFileSystemTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -104,7 +105,7 @@ public final class EncryptedFileSystemTest {
         myIs.close();
         fs.close();
 
-        verify(is).close();
+        verify(is, atLeastOnce()).close();
     }
 
     @Test


### PR DESCRIPTION
The following backtrace shows previously doing single byte read() which is inefficient, so lets support bulk reads.

```
com.sun.crypto.provider.CipherCore.update(byte[], int, int)
com.sun.crypto.provider.AESCipher.engineUpdate(byte[], int, int)
javax.crypto.Cipher.update(byte[], int, int)
javax.crypto.CipherInputStream.getMoreData()
javax.crypto.CipherInputStream.read()
com.palantir.hadoop.cipher.FsCipherInputStream.read()
java.io.InputStream.read(byte[], int, int)
```