### PR TITLE
Add async methods to KeyStorageStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         maven { url  "http://palantir.bintray.com/releases" }
+        jcenter()
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url  "http://palantir.bintray.com/releases" }
     }
 
     dependencies {

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/ChainedKeyStorageStrategy.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/ChainedKeyStorageStrategy.java
@@ -73,7 +73,7 @@ public final class ChainedKeyStorageStrategy implements KeyStorageStrategy {
         List<Supplier<CompletableFuture<KeyMaterial>>> futures = strategies.stream()
                 .skip(1)
                 .map(strategy -> (Supplier<CompletableFuture<KeyMaterial>>)
-                        Suppliers.memoize(() -> strategy.getAsync("fileKey"))::get)
+                        Suppliers.memoize(() -> strategy.getAsync(fileKey))::get)
                 .collect(Collectors.toList());
 
         CompletableFuture<KeyMaterial> accumulated = strategies.get(0).getAsync(fileKey);

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/ChainedKeyStorageStrategy.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/ChainedKeyStorageStrategy.java
@@ -17,7 +17,6 @@
 package com.palantir.crypto2.keys;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Collections2;
 import java.util.Arrays;
 import java.util.List;
@@ -72,8 +71,7 @@ public final class ChainedKeyStorageStrategy implements KeyStorageStrategy {
     public CompletableFuture<KeyMaterial> getAsync(String fileKey) {
         List<Supplier<CompletableFuture<KeyMaterial>>> futures = strategies.stream()
                 .skip(1)
-                .map(strategy -> (Supplier<CompletableFuture<KeyMaterial>>)
-                        Suppliers.memoize(() -> strategy.getAsync(fileKey))::get)
+                .map(strategy -> (Supplier<CompletableFuture<KeyMaterial>>) () -> strategy.getAsync(fileKey))
                 .collect(Collectors.toList());
 
         CompletableFuture<KeyMaterial> accumulated = strategies.get(0).getAsync(fileKey);

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/KeyStorageStrategy.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/KeyStorageStrategy.java
@@ -33,8 +33,16 @@ public interface KeyStorageStrategy {
      */
     KeyMaterial get(String fileKey);
 
+    /**
+     * Retrieves the {@link KeyMaterial} for a file with the given {@code fileKey},
+     * returning a {@link CompletableFuture}. Consumers should expect this to execute
+     * in a nonblocking fashion.
+     *
+     * By default uses the common fork-join pool - implementers will likely want to
+     * change this behaviour in non-trivial cases.
+     */
     default CompletableFuture<KeyMaterial> getAsync(String fileKey) {
-        return CompletableFuture.completedFuture(get(fileKey));
+        return CompletableFuture.supplyAsync(() -> get(fileKey));
     }
 
     /**

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/KeyStorageStrategy.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/KeyStorageStrategy.java
@@ -16,6 +16,8 @@
 
 package com.palantir.crypto2.keys;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * The strategy used to store the per file {@link KeyMaterial} used for encryption operations.
  */
@@ -30,6 +32,10 @@ public interface KeyStorageStrategy {
      * Retrieves the {@link KeyMaterial} for a file with the given {@code fileKey}.
      */
     KeyMaterial get(String fileKey);
+
+    default CompletableFuture<KeyMaterial> getAsync(String fileKey) {
+        return CompletableFuture.completedFuture(get(fileKey));
+    }
 
     /**
      * Removes the {@link KeyMaterial} for a file with the given {@code fileKey}.


### PR DESCRIPTION
At the moment, the KeyStorageStrategy is blocking - it'd be really nice if there was an async version people could use.