### PR TITLE
Remove SunJCE hardcode

### DIFF
--- a/crypto-core/src/main/java/com/palantir/crypto2/cipher/AesCbcCipher.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/cipher/AesCbcCipher.java
@@ -23,7 +23,6 @@ import com.palantir.crypto2.keys.serialization.KeyMaterials;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
@@ -36,7 +35,6 @@ import javax.crypto.spec.IvParameterSpec;
 public final class AesCbcCipher implements SeekableCipher {
 
     public static final String ALGORITHM = "AES/CBC/PKCS5Padding";
-    private static final String PROVIDER = "SunJCE";
     private static final String KEY_ALGORITHM = "AES";
     private static final int KEY_SIZE = 256;
     private static final int BLOCK_SIZE = 16;
@@ -96,8 +94,8 @@ public final class AesCbcCipher implements SeekableCipher {
 
     private Cipher getInstance() {
         try {
-            return Cipher.getInstance(ALGORITHM, PROVIDER);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException e) {
+            return Cipher.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw Throwables.propagate(e);
         }
     }

--- a/crypto-core/src/main/java/com/palantir/crypto2/cipher/AesCtrCipher.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/cipher/AesCtrCipher.java
@@ -24,7 +24,6 @@ import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
@@ -37,7 +36,6 @@ import javax.crypto.spec.IvParameterSpec;
 public final class AesCtrCipher implements SeekableCipher {
 
     public static final String ALGORITHM = "AES/CTR/NoPadding";
-    static final String PROVIDER = "SunJCE";
     static final String KEY_ALGORITHM = "AES";
     static final int KEY_SIZE = 256;
     static final int BLOCK_SIZE = 16;
@@ -122,8 +120,8 @@ public final class AesCtrCipher implements SeekableCipher {
 
     private Cipher getInstance() {
         try {
-            return Cipher.getInstance(ALGORITHM, PROVIDER);
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException e) {
+            return Cipher.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw Throwables.propagate(e);
         }
     }


### PR DESCRIPTION
Removes the hardcode on provider so that it can work on systems without SunJCE, such as IBM's AIX.