### PR TITLE
Newer version of seek-io

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.*:jackson-* = 2.6.1
 com.google.guava:guava = 18.0
-com.palantir.seek-io:seek-io = 1.0.2
+com.palantir.seek-io:seek-io = 1.3.0
 junit:junit = 4.12
 org.apache.commons:commons-crypto = 1.0.0
 org.apache.hadoop:hadoop-common = 2.7.3


### PR DESCRIPTION
An internal project depends on hadoop-crypto and when you depend on it, it generates dependency conflicts because it needs a newer version which requires manual resolution. Seems reasonable to pick up minor version bumps.