### PR TITLE
Sr/fix distcp

### DIFF
--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
@@ -91,7 +91,7 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
         FSDataOutputStream encryptedStream =
                 fs.create(path, permission, overwrite, bufferSize, replication, blockSize, progress);
 
-        return storeKey(encryptedStream, path);
+        return encrypt(encryptedStream, path);
     }
 
     @Override
@@ -100,10 +100,10 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
         FSDataOutputStream encryptedStream =
                 fs.create(path, permission, flags, bufferSize, replication, blockSize, progress, checksumOpt);
 
-        return storeKey(encryptedStream, path);
+        return encrypt(encryptedStream, path);
     }
 
-    private FSDataOutputStream storeKey(FSDataOutputStream encryptedStream, Path path) throws IOException {
+    private FSDataOutputStream encrypt(FSDataOutputStream encryptedStream, Path path) throws IOException {
         KeyMaterial keyMaterial = SeekableCipherFactory.generateKeyMaterial(cipherAlgorithm);
         SeekableCipher cipher = SeekableCipherFactory.getCipher(cipherAlgorithm, keyMaterial);
 

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
@@ -91,24 +91,19 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
         FSDataOutputStream encryptedStream =
                 fs.create(path, permission, overwrite, bufferSize, replication, blockSize, progress);
 
-        KeyMaterial keyMaterial = SeekableCipherFactory.generateKeyMaterial(cipherAlgorithm);
-        SeekableCipher cipher = SeekableCipherFactory.getCipher(cipherAlgorithm, keyMaterial);
-
-        // Ensure we can open the stream before storing keys that would be irrelevant
-        OutputStream encryptedOs =
-                CryptoStreamFactory.encrypt(encryptedStream, cipher.getKeyMaterial(), cipherAlgorithm);
-        FSDataOutputStream os = new FSDataOutputStream(encryptedOs, statistics);
-        keyStore.put(path.toString(), cipher.getKeyMaterial());
-
-        return os;
+        return storeKey(encryptedStream, path);
     }
 
     @Override
     public FSDataOutputStream create(Path path, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
-            short replication, long blockSize, Progressable progress, Options.ChecksumOpt checksumOpt) throws IOException {
+            short replication, long blockSize, Progressable progress, ChecksumOpt checksumOpt) throws IOException {
         FSDataOutputStream encryptedStream =
                 fs.create(path, permission, flags, bufferSize, replication, blockSize, progress, checksumOpt);
 
+        return storeKey(encryptedStream, path);
+    }
+
+    private FSDataOutputStream storeKey(FSDataOutputStream encryptedStream, Path path) throws IOException {
         KeyMaterial keyMaterial = SeekableCipherFactory.generateKeyMaterial(cipherAlgorithm);
         SeekableCipher cipher = SeekableCipherFactory.getCipher(cipherAlgorithm, keyMaterial);
 

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Options.ChecksumOpt;
@@ -123,6 +124,11 @@ public final class PathConvertingFileSystem extends DelegatingFileSystem {
     @Override
     public boolean mkdirs(Path path, FsPermission permission) throws IOException {
         return delegate.mkdirs(to(path), permission);
+    }
+
+    @Override
+    public FileChecksum getFileChecksum(Path path) throws IOException {
+        return fs.getFileChecksum(to(path));
     }
 
     private Path to(Path path) {

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
@@ -18,11 +18,14 @@ package com.palantir.crypto2.hadoop;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.EnumSet;
 import java.util.function.Function;
+import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
@@ -65,6 +68,12 @@ public final class PathConvertingFileSystem extends DelegatingFileSystem {
             short replication, long blockSize, Progressable progress) throws IOException {
         return delegate.create(to(path), permission, overwrite, bufferSize, replication, blockSize,
                 progress);
+    }
+
+    @Override
+    public FSDataOutputStream create(Path path, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize,
+            short replication, long blockSize, Progressable progress, ChecksumOpt checksumOpt) throws IOException {
+        return delegate.create(to(path), permission, flags, bufferSize, replication, blockSize, progress, checksumOpt);
     }
 
     @Override

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
@@ -78,8 +78,8 @@ public final class PathConvertingFileSystemTest {
         when(delegate.create(DELEGATE_PATH, null, false, 0, (short) 0, 0, null)).thenReturn(outputStream);
         FSDataOutputStream actualStream = convertingFs.create(PATH, null, false, 0, (short) 0, 0, null);
 
-        when(delegate.create(DELEGATE_PATH, null, null, 0, (short)0, 0, null, null)).thenReturn(outputStream);
-        FSDataOutputStream actualStream1 = convertingFs.create(PATH, null, null, 0, (short)0, 0, null, null);
+        when(delegate.create(DELEGATE_PATH, null, null, 0, (short) 0, 0, null, null)).thenReturn(outputStream);
+        FSDataOutputStream actualStream1 = convertingFs.create(PATH, null, null, 0, (short) 0, 0, null, null);
 
         assertThat(actualStream).isEqualTo(outputStream);
         assertThat(actualStream1).isEqualTo(outputStream);

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
@@ -160,7 +160,7 @@ public final class PathConvertingFileSystemTest {
         when(delegate.getFileChecksum(DELEGATE_PATH)).thenReturn(fileChecksum);
         FileChecksum checksum = convertingFs.getFileChecksum(PATH);
 
-        assertThat(checksum.equals(fileChecksum));
+        assertThat(checksum).isEqualTo(fileChecksum);
     }
 
     private static FileStatus fileStatus(Path path) {

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
@@ -22,15 +22,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.util.EnumSet;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Options.ChecksumOpt;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Somewhere between 2.3.2 and 2.3.4, distcp from `hdfs://...` to `ehdfs://...` got broken in a few ways:

* The version of `create` that distcp uses doesn't know to write a key to the keystore -- need to have EFS call `keyStore.put`
* Need PathConvertingFS to convert the path for the version of `create` that it's using
* Need PathConvertingFS to convert the path for the version of `getFileChecksum` that it's using

This code works, but should probably understand what exactly in the 2.3.2 -> 2.3.4 bump caused these issues, thus the "don't merge" for now. Likely suspect seems to be the move to DelegatingFS, though it's not obvious to me why exactly. Will look more tomorrow, but won't complain if someone wants to figure it out while I'm asleep :)

Also it wasn't necessary to pass the `-skipcrccheck` flag to distcp on 2.3.2, but it is on this branch. Otherwise distcp gets confused that the checksums don't match (which makes sense given the unencrypted source files and encrypted destination files).