### PR TITLE
Add support for recursive delete in EncryptedFileSystem

### DIFF
--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
@@ -27,7 +27,6 @@ import com.palantir.crypto2.keys.KeyStorageStrategy;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
@@ -347,9 +347,9 @@ public final class EncryptedFileSystemTest {
     public void testDelete_recursiveDelete() throws IOException {
         Path folderPath = new Path(folder.getRoot().getAbsolutePath());
 
-        assertThatExceptionOfType(UnsupportedOperationException.class)
-                .isThrownBy(() -> efs.delete(folderPath, true))
-                .withMessage("EncryptedFileSystem does not support recursive deletes");
+        assertThat(efs.delete(folderPath, true)).isTrue();
+        assertThat(efs.exists(folderPath)).isFalse();
+        assertThat(efs.exists(path)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/palantir/hadoop-crypto/issues/117

We want to be able to delete folders of many items. CC @eraboin

If this change seems generally reasonable, I can add more tests