### PR TITLE
Wrap with CBC for symmetric, not GCM

### DIFF
--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/CipherSymmetricKeySerializer.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/CipherSymmetricKeySerializer.java
@@ -1,0 +1,133 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.crypto2.keys.serialization;
+
+import com.google.common.base.Preconditions;
+import com.palantir.crypto2.keys.KeyMaterial;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.SecretKey;
+
+/**
+ * Serializer for wrapping and unwrapping {@link KeyMaterial}. The {@link #wrap} method returns the KeyMaterial
+ * serialized as follows, which is the same format the {@link #unwrap} method expects:
+ *
+ * <pre>
+ *  +--------------------------------------------------------------+
+ *  | version | wrapping iv | key algorithm length | key algorithm |
+ *  |   byte  |    byte[]   |          int         |     byte[]    |
+ *  +--------------------------------------------------------------+
+ *  +-------------------------------------------------------+
+ *  | wrapped key length | wrapped key | iv length |   iv   |
+ *  |        int         |    byte[]   |    int    | byte[] |
+ *  +-------------------------------------------------------+
+ * </pre>
+ */
+public final class CipherSymmetricKeySerializer implements SymmetricKeySerializer {
+    private final int ivSize;
+    private final int version;
+    private final CipherFactory cipherFactory;
+
+    public CipherSymmetricKeySerializer(int ivSize, int version, CipherFactory cipherFactory) {
+        this.ivSize = ivSize;
+        this.version = version;
+        this.cipherFactory = cipherFactory;
+    }
+
+    @Override
+    public byte[] wrap(KeyMaterial keyMaterial, SecretKey key) {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        DataOutputStream stream = new DataOutputStream(byteStream);
+
+        byte[] wrappingIv = KeyMaterials.generateIv(ivSize);
+        Cipher keyWrappingCipher = cipherFactory.getCipher(Cipher.WRAP_MODE, key, wrappingIv);
+        SecretKey secretKey = keyMaterial.getSecretKey();
+
+        try {
+            stream.write(version);
+
+            stream.write(wrappingIv);
+
+            String keyAlgorithm = secretKey.getAlgorithm();
+            stream.writeInt(keyAlgorithm.length());
+            stream.write(keyAlgorithm.getBytes(StandardCharsets.UTF_8));
+
+            byte[] encryptedKey = keyWrappingCipher.wrap(secretKey);
+            stream.writeInt(encryptedKey.length);
+            stream.write(encryptedKey);
+
+            byte[] iv = keyMaterial.getIv();
+            stream.writeInt(iv.length);
+            stream.write(iv);
+
+            stream.close();
+            return byteStream.toByteArray();
+        } catch (IOException | InvalidKeyException | IllegalBlockSizeException e) {
+            throw new RuntimeException("Unable to wrap key", e);
+        }
+    }
+
+    @Override
+    public KeyMaterial unwrap(byte[] wrappedKeyMaterial, SecretKey key) {
+        DataInputStream stream = new DataInputStream(new ByteArrayInputStream(wrappedKeyMaterial));
+
+        try {
+            int readVersion = stream.read();
+            Preconditions.checkArgument(readVersion == version,
+                    "Invalid serialization format version. Expected %s but found %s", readVersion, version);
+
+            byte[] wrappingIv = new byte[ivSize];
+            stream.readFully(wrappingIv);
+            Cipher keyUnwrappingCipher = cipherFactory.getCipher(Cipher.UNWRAP_MODE, key, wrappingIv);
+
+            int algorithmLength = stream.readInt();
+            byte[] algorithmBytes = new byte[algorithmLength];
+            stream.readFully(algorithmBytes);
+
+            int keyLength = stream.readInt();
+            byte[] secretKeyBytes = new byte[keyLength];
+            stream.readFully(secretKeyBytes);
+
+            int ivLength = stream.readInt();
+            byte[] iv = new byte[ivLength];
+            stream.readFully(iv);
+
+            String algorithm = new String(algorithmBytes, StandardCharsets.UTF_8);
+            SecretKey secretKey = (SecretKey) keyUnwrappingCipher.unwrap(secretKeyBytes, algorithm, Cipher.SECRET_KEY);
+            return KeyMaterial.of(secretKey, iv);
+        } catch (InvalidKeyException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Unable to unwrap key", e);
+        }
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    interface CipherFactory {
+        Cipher getCipher(int cipherMode, SecretKey secretKey, byte[] iv);
+    }
+}

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/KeyMaterials.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/KeyMaterials.java
@@ -89,7 +89,7 @@ public final class KeyMaterials {
      * See {@link SymmetricKeySerializer} to understand when to use {@link #wrap} vs. {@link #symmetricWrap}.
      */
     public static byte[] symmetricWrap(KeyMaterial keyMaterial, SecretKey key) {
-        return SymmetricKeySerializerV3.INSTANCE.wrap(keyMaterial, key);
+        return SymmetricKeySerializerV4.INSTANCE.wrap(keyMaterial, key);
     }
 
     public static KeyMaterial unwrap(byte[] wrappedKeyMaterial, PrivateKey key) {

--- a/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/KeySerializers.java
+++ b/crypto-keys/src/main/java/com/palantir/crypto2/keys/serialization/KeySerializers.java
@@ -31,7 +31,8 @@ final class KeySerializers {
             KeySerializerV1.INSTANCE.getVersion(), KeySerializerV1.INSTANCE,
             KeySerializerV2.INSTANCE.getVersion(), KeySerializerV2.INSTANCE);
     private static final Map<Integer, ? extends SymmetricKeySerializer> SYMMETRIC_SERIALIZERS = ImmutableMap.of(
-            SymmetricKeySerializerV3.INSTANCE.getVersion(), SymmetricKeySerializerV3.INSTANCE);
+            SymmetricKeySerializerV3.INSTANCE.getVersion(), SymmetricKeySerializerV3.INSTANCE,
+            SymmetricKeySerializerV4.INSTANCE.getVersion(), SymmetricKeySerializerV4.INSTANCE);
 
     private KeySerializers() {}
 

--- a/crypto-keys/src/test/java/com/palantir/crypto2/keys/serialization/SymmetricKeySerializerV4Test.java
+++ b/crypto-keys/src/test/java/com/palantir/crypto2/keys/serialization/SymmetricKeySerializerV4Test.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.crypto2.keys.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.crypto2.keys.KeyMaterial;
+import org.junit.Test;
+
+public final class SymmetricKeySerializerV4Test {
+
+    private static final SymmetricKeySerializerV4 SERIALIZER = SymmetricKeySerializerV4.INSTANCE;
+    private static final String KEY_ALG = "AES";
+    private static final int KEY_SIZE = 128;
+    private static final int IV_SIZE = 16;
+
+    @Test
+    public void testWrapUnwrap() {
+        KeyMaterial wrappingKeyMaterial = KeyMaterials.generateKeyMaterial(KEY_ALG, KEY_SIZE, IV_SIZE);
+        KeyMaterial keyMaterial = KeyMaterials.generateKeyMaterial(KEY_ALG, KEY_SIZE, IV_SIZE);
+
+        byte[] wrapped = SERIALIZER.wrap(keyMaterial, wrappingKeyMaterial.getSecretKey());
+        KeyMaterial unwrapped = SERIALIZER.unwrap(wrapped, wrappingKeyMaterial.getSecretKey());
+        assertThat(keyMaterial).isEqualTo(unwrapped);
+    }
+
+    @Test
+    public void testNewIvUsed() {
+        KeyMaterial wrappingKeyMaterial = KeyMaterials.generateKeyMaterial(KEY_ALG, KEY_SIZE, IV_SIZE);
+        KeyMaterial keyMaterial = KeyMaterials.generateKeyMaterial(KEY_ALG, KEY_SIZE, IV_SIZE);
+
+        byte[] wrapped1 = SERIALIZER.wrap(keyMaterial, wrappingKeyMaterial.getSecretKey());
+        byte[] wrapped2 = SERIALIZER.wrap(keyMaterial, wrappingKeyMaterial.getSecretKey());
+        assertThat(wrapped1).isNotEqualTo(wrapped2);
+    }
+}


### PR DESCRIPTION
GCM is inferior to CBC here for two reasons.

1. GCM is much more wholly broken in the case that IV reuse happens for
a key.
2. GCM has a smaller IV (96 bits vs 128 bits) than CBC.

Or, to put it in terms of NIST's recommendations, you shouldn't use GCM
for more than 2^32 encryptions with a single key,
https://csrc.nist.gov/publications/detail/sp/800-38d/final (section 8.3).

Which the current setup encourage.

By using CBC instead, the birthday paradox becomes a lot less likely to
be hit (16 more bits of entropy in the IV), and the cost of hitting it
is much less drastic (you can only work out whether two keys have a
common prefix, which isn't useful)