### PR TITLE
Log the exception when failing to create a ApacheCtrDecryptingSeekableInput

### DIFF
--- a/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
@@ -60,7 +60,7 @@ public final class CryptoStreamFactory {
         try {
             return new ApacheCtrDecryptingSeekableInput(encryptedInput, keyMaterial);
         } catch (IOException e) {
-            log.warn("Unable to initialize cipher with OpenSSL falling back to JCE implementation");
+            log.warn("Unable to initialize cipher with OpenSSL falling back to JCE implementation", e);
             return new DecryptingSeekableInput(encryptedInput, SeekableCipherFactory.getCipher(algorithm, keyMaterial));
         }
     }


### PR DESCRIPTION
Log the exception when failing to create a `ApacheCtrDecryptingSeekableInput`