### PR TITLE
log exception when CryptoStreamFactory is unable to use fast codepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,44 @@ Hadoop Configuration Properties
 License
 -------
 This repository is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
+
+
+FAQ
+---
+
+## log.warn lines from `CryptoStreamFactory`
+
+`WARN: Unable to initialize cipher with OpenSSL, falling back to JCE implementation`
+
+'Falling back to the JCE implementation' results in slower cipher performance than native OpenSSL. Resolve this by installing a compatible OpenSSL and symlinking it to the correct location, `/usr/lib/libcrypto.so`. (OpenSSL 1.0 and 1.1 are currently supported)
+
+_Note: to support OpenSSL 1.1, we use releases from the [Palantir fork of commons-crypto](https://github.com/palantir/commons-crypto/releases) as support has been added to the mainline Apache repo, but no release made [since 2016](https://github.com/apache/commons-crypto/releases)._
+
+```
+Exception in thread "main" java.io.IOException: java.security.GeneralSecurityException: CryptoCipher {org.apache.commons.crypto.cipher.OpenSslCipher} is not available or transformation AES/CTR/NoPadding is not supported.
+	at org.apache.commons.crypto.utils.Utils.getCipherInstance(Utils.java:130)
+	at ApacheCommonsCryptoLoad.main(ApacheCommonsCryptoLoad.java:10)
+Caused by: java.security.GeneralSecurityException: CryptoCipher {org.apache.commons.crypto.cipher.OpenSslCipher} is not available or transformation AES/CTR/NoPadding is not supported.
+	at org.apache.commons.crypto.cipher.CryptoCipherFactory.getCryptoCipher(CryptoCipherFactory.java:176)
+	at org.apache.commons.crypto.utils.Utils.getCipherInstance(Utils.java:128)
+	... 1 more
+Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
+	at org.apache.commons.crypto.utils.ReflectionUtils.newInstance(ReflectionUtils.java:90)
+	at org.apache.commons.crypto.cipher.CryptoCipherFactory.getCryptoCipher(CryptoCipherFactory.java:160)
+	... 2 more
+Caused by: java.lang.reflect.InvocationTargetException
+	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
+	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source)
+	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source)
+	at java.base/java.lang.reflect.Constructor.newInstance(Unknown Source)
+	at org.apache.commons.crypto.utils.ReflectionUtils.newInstance(ReflectionUtils.java:88)
+	... 3 more
+Caused by: java.lang.RuntimeException: java.lang.UnsatisfiedLinkError: EVP_CIPHER_CTX_cleanup
+	at org.apache.commons.crypto.cipher.OpenSslCipher.<init>(OpenSslCipher.java:59)
+	... 8 more
+Caused by: java.lang.UnsatisfiedLinkError: EVP_CIPHER_CTX_cleanup
+	at org.apache.commons.crypto.cipher.OpenSslNative.initIDs(Native Method)
+	at org.apache.commons.crypto.cipher.OpenSsl.<clinit>(OpenSsl.java:95)
+	at org.apache.commons.crypto.cipher.OpenSslCipher.<init>(OpenSslCipher.java:57)
+	... 8 more
+```

--- a/changelog/@unreleased/pr-302.v2.yml
+++ b/changelog/@unreleased/pr-302.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: When CryptoStreamFactory is unable to use apache commons-crypto's fast
+    native codepath, the WARN log line now includes the exception
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/302

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
@@ -105,7 +105,8 @@ public final class CryptoStreamFactory {
     private static void maybeLogException(IOException exception) {
         long now = System.currentTimeMillis();
         long prev = mostRecentLoggedExceptionTimestamp.get();
-        if (now - prev > DELAY_BETWEEN_LOGGED_EXCEPTIONS && mostRecentLoggedExceptionTimestamp.compareAndSet(prev, now)) {
+        if (now - prev > DELAY_BETWEEN_LOGGED_EXCEPTIONS
+                && mostRecentLoggedExceptionTimestamp.compareAndSet(prev, now)) {
             log.warn("Exception for stack trace", exception);
         }
     }

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
@@ -60,7 +60,7 @@ public final class CryptoStreamFactory {
         try {
             return new ApacheCtrDecryptingSeekableInput(encryptedInput, keyMaterial);
         } catch (IOException e) {
-            log.warn("Unable to initialize cipher with OpenSSL falling back to JCE implementation");
+            log.warn("Unable to initialize cipher with OpenSSL falling back to JCE implementation", e);
             return new DecryptingSeekableInput(encryptedInput, SeekableCipherFactory.getCipher(algorithm, keyMaterial));
         }
     }
@@ -91,7 +91,7 @@ public final class CryptoStreamFactory {
         try {
             return createApacheEncryptedStream(output, keyMaterial);
         } catch (IOException e) {
-            log.warn("Unable to initialize cipher with OpenSSL, falling back to JCE implementation");
+            log.warn("Unable to initialize cipher with OpenSSL, falling back to JCE implementation", e);
             return createDefaultEncryptedStream(output, keyMaterial, algorithm);
         }
     }


### PR DESCRIPTION
## Before this PR

Looking in our internal log searching app for `origin:*CryptoStreamFactory*`, I found a _ton_ of services are not hitting the fast codepath. (Including our data ingestion coordinator on our dogfooding deployment).

> Unable to initialize cipher with OpenSSL, falling back to JCE implementation

This is somewhat expected for spark modules, but weird for regular cloud deployed services. @robert3005's hypothesis is just that OpenSSL is symlinked to the wrong place on those boxes, but it's hard to be certain without seeing the exception.

## After this PR
==COMMIT_MSG==
When CryptoStreamFactory is unable to use apache commons-crypto's fast native codepath, the WARN log line now includes the exception
==COMMIT_MSG==

## Possible downsides?
- more noise in logs?


