### PR TITLE
Don't initialize the FS twice

### DIFF
--- a/changelog/@unreleased/pr-332.v2.yml
+++ b/changelog/@unreleased/pr-332.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Don't initialize the backing file system twice.
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/332

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
@@ -119,7 +119,6 @@ public final class StandaloneEncryptedFileSystem extends FilterFileSystem {
         URI backingUri = setUriSchemeFunc(backingScheme).apply(uri);
 
         FileSystem backingFs = FileSystem.get(backingUri, conf);
-        backingFs.initialize(backingUri, conf);
 
         return new PathConvertingFileSystem(
                 backingFs,

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
@@ -118,6 +118,7 @@ public final class StandaloneEncryptedFileSystem extends FilterFileSystem {
         String backingScheme = encryptedScheme.substring(1);
         URI backingUri = setUriSchemeFunc(backingScheme).apply(uri);
 
+        // Do not call `initialize` as Filesystem#get calls `initialize` prior to returning the FileSystem
         FileSystem backingFs = FileSystem.get(backingUri, conf);
 
         return new PathConvertingFileSystem(


### PR DESCRIPTION
## Before this PR
`FileSystem.get` [already calls initialize()](https://github.com/apache/hadoop/blob/rel/release-3.2.1/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3303) within `createFileSystem()`.

Initializing twice leads to memory leaks since anything that is allocated within the first `initialize()` call cannot be closed.

## After this PR
==COMMIT_MSG==
Don't initialize the backing file system twice.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

