### PR TITLE
Reuse a buffer in ACDSI.InputAdapter

### DIFF
--- a/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
@@ -112,6 +112,7 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
 
         @Override
         public void close() throws IOException {
+            readBuffer = null;
             input.close();
         }
 

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
@@ -117,30 +117,18 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
         }
 
         private void resize(int required) {
-            int size = readBuffer.length;
-            readBuffer = new byte[newLength(size, required - size, size << 1)];
+            readBuffer = new byte[newLength(readBuffer.length, required)];
         }
 
-        // copied from jdk.internal.util.ArraysSupport
+        // some jvms reserve header words in an array, reducing its max size
         private static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
-        private static int newLength(int oldLength, int minGrowth, int prefGrowth) {
-            // assert oldLength >= 0
-            // assert minGrowth > 0
-
-            int newLength = Math.max(minGrowth, prefGrowth) + oldLength;
+        private static int newLength(int oldLength, int targetLength) {
+            int newLength = Math.max(targetLength, oldLength << 1);
             if (newLength - MAX_ARRAY_LENGTH <= 0) {
                 return newLength;
             }
-            return hugeLength(oldLength, minGrowth);
-        }
-
-        private static int hugeLength(int oldLength, int minGrowth) {
-            int minLength = oldLength + minGrowth;
-            if (minLength < 0) { // overflow
-                throw new OutOfMemoryError("Required array length too large");
-            }
-            if (minLength <= MAX_ARRAY_LENGTH) {
+            if (targetLength - MAX_ARRAY_LENGTH <= 0) {
                 return MAX_ARRAY_LENGTH;
             }
             return Integer.MAX_VALUE;

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
@@ -85,7 +85,7 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
             if (readBuffer.length < dst.remaining()) {
                 resize(dst.remaining());
             }
-            int read = input.read(readBuffer, 0, readBuffer.length);
+            int read = input.read(readBuffer, 0, dst.remaining());
 
             if (read != -1) {
                 dst.put(readBuffer, 0, read);

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
@@ -67,8 +67,8 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
     }
 
     private static final class InputAdapter implements Input {
-        private SeekableInput input;
-        private byte[] readBuffer = new byte[BUFFER_SIZE];
+        private final SeekableInput input;
+        private final byte[] readBuffer = new byte[BUFFER_SIZE];
 
         private InputAdapter(SeekableInput input) {
             this.input = input;
@@ -119,7 +119,6 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
 
         @Override
         public void close() throws IOException {
-            readBuffer = null;
             input.close();
         }
     }

--- a/crypto-core/src/test/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInputTests.java
+++ b/crypto-core/src/test/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInputTests.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.crypto2.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.seekio.InMemorySeekableDataInput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public final class ApacheCtrDecryptingSeekableInputTests {
+    private static final int NUM_BYTES = 1024 * 1024;
+    private static final Random random = new Random(0);
+    private static byte[] data;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        data = new byte[NUM_BYTES];
+        random.nextBytes(data);
+    }
+
+    @Test
+    public void testEmptyRead() throws IOException {
+        ByteBuffer dst = ByteBuffer.allocate(1024);
+        byte[] emptyData = new byte[] {};
+
+        ApacheCtrDecryptingSeekableInput.InputAdapter adapter = inputAdapter(emptyData);
+        assertThat(adapter.read(dst)).isEqualTo(-1);
+        assertThat(dst.position()).isEqualTo(0);
+    }
+
+    @Test
+    public void testFullRead() throws IOException {
+        ByteBuffer dst = ByteBuffer.allocate(2 * NUM_BYTES);
+
+        ApacheCtrDecryptingSeekableInput.InputAdapter adapter = inputAdapter(data);
+        assertThat(adapter.read(dst)).isEqualTo(NUM_BYTES);
+        assertThat(dst.position()).isEqualTo(NUM_BYTES);
+    }
+
+    @Test
+    public void testPartialRead() throws IOException {
+        int toRead = NUM_BYTES / 2;
+        ByteBuffer dst = ByteBuffer.allocate(toRead);
+
+        ApacheCtrDecryptingSeekableInput.InputAdapter adapter = inputAdapter(data);
+        assertThat(adapter.read(dst)).isEqualTo(toRead);
+        assertThat(dst.position()).isEqualTo(toRead);
+    }
+
+    private ApacheCtrDecryptingSeekableInput.InputAdapter inputAdapter(byte[] inputData) {
+        return new ApacheCtrDecryptingSeekableInput.InputAdapter(new InMemorySeekableDataInput(inputData));
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The allocation in .read was 30% of all allocations in internal product
during a period where we were allocating and GCing ~20GB of byte[]s
per minute.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reduce byte[] allocations during reads via ApacheCtrDecryptingSeekableInput
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

