### PR TITLE
CryptoStreamFactory creates sympathetic chunking OutputStreams

### DIFF
--- a/changelog/@unreleased/pr-587.v2.yml
+++ b/changelog/@unreleased/pr-587.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: CryptoStreamFactory creates sympathetic chunking OutputStreams with
+    performance characteristics _matching_ the apache commons-crypto implementation
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/587

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
@@ -159,6 +159,15 @@ public final class CryptoStreamFactory {
      */
     static final class ChunkingOutputStream extends FilterOutputStream {
 
+        /**
+         * Chunk size of 16 KB is small enough to allow cipher implementations to become hot and optimize properly
+         * when given large inputs. Otherwise large array writes into a {@link CipherOutputStream} fail to use
+         * intrinsified implementations. If 16 KB chunks aren't enough to produce hot methods, the I/O is small
+         * and infrequent enough that performance isn't relevant.
+         * For more information, see the details around {@code com.sun.crypto.provider.GHASH::processBlocks} in
+         * <a href="https://github.com/palantir/hadoop-crypto/pull/586#issuecomment-964394587">
+         * hadoop-crypto#586 (comment)</a>
+         */
         private static final int CHUNK_SIZE = 16 * 1024;
 
         ChunkingOutputStream(OutputStream delegate) {


### PR DESCRIPTION
For detailed analysis of the problem, see
https://github.com/palantir/hadoop-crypto/pull/586

CipherOutputStream appears to perform _very_ poorly on large
buffers, but substantially better when data is segmented into
small chunks which can be done by looping over the original buffer.

With this in place, the openssl wrappeer no longer provides any
benefit over JCE.

==COMMIT_MSG==
CryptoStreamFactory creates sympathetic chunking OutputStreams with performance characteristics _matching_ the apache commons-crypto implementation
==COMMIT_MSG==

