### PR TITLE
CryptoStreamFactory logs reasonably when OpenSSL is or isn't detected

### DIFF
--- a/changelog/@unreleased/pr-592.v2.yml
+++ b/changelog/@unreleased/pr-592.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: CryptoStreamFactory logs once at `INFO` whether OpenSSL is detected.
+    Systems without OpenSSL no longer log a warning each time encryption or decryption
+    is used.
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/592

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/ApacheCtrDecryptingSeekableInput.java
@@ -23,6 +23,7 @@ import com.palantir.seekio.SeekableInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Properties;
+import org.apache.commons.crypto.cipher.CryptoCipher;
 import org.apache.commons.crypto.stream.CtrCryptoInputStream;
 import org.apache.commons.crypto.stream.input.Input;
 import org.apache.commons.crypto.utils.Utils;
@@ -43,8 +44,12 @@ public final class ApacheCtrDecryptingSeekableInput extends CtrCryptoInputStream
      * the OpenSSL library is able to be loaded.
      */
     ApacheCtrDecryptingSeekableInput(SeekableInput input, KeyMaterial keyMaterial) throws IOException {
-        super(new InputAdapter(input), Utils.getCipherInstance(ALGORITHM, PROPS), BUFFER_SIZE,
+        super(new InputAdapter(input), getCipherInstance(), BUFFER_SIZE,
                 keyMaterial.getSecretKey().getEncoded(), keyMaterial.getIv());
+    }
+
+    static CryptoCipher getCipherInstance() throws IOException {
+        return Utils.getCipherInstance(ALGORITHM, PROPS);
     }
 
     @Override

--- a/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
+++ b/crypto-core/src/main/java/com/palantir/crypto2/io/CryptoStreamFactory.java
@@ -41,10 +41,6 @@ public final class CryptoStreamFactory {
     private static final Logger log = LoggerFactory.getLogger(CryptoStreamFactory.class);
     private static final Properties PROPS = ApacheCiphers.forceOpenSsl(new Properties());
     private static final String AES_ALGORITHM = "AES/CTR/NoPadding";
-    private static final String OPEN_SSL_INIT_WARNING = "Unable to initialize cipher with OpenSSL, falling back to "
-            + "JCE implementation - see github.com/palantir/hadoop-crypto#faq";
-
-    private static volatile boolean fullExceptionLoggedAlready = false;
 
     private static final Supplier<Boolean> OPENSSL_IS_AVAILABLE = Suppliers.memoize(() -> {
         try {
@@ -52,7 +48,8 @@ public final class CryptoStreamFactory {
             log.info("Detected OpenSSL: the openssl native implementation will be used for AES/CTR/NoPadding");
             return true;
         } catch (Throwable t) {
-            log.info(OPEN_SSL_INIT_WARNING, t);
+            log.info("Unable to initialize cipher with OpenSSL, falling back to "
+                    + "JCE implementation - see github.com/palantir/hadoop-crypto#faq", t);
             return false;
         }
     });
@@ -64,22 +61,20 @@ public final class CryptoStreamFactory {
      * cipher {@code algorithm}. When OpenSSL is available an implementation that uses AES-NI will be returned.
      */
     public static SeekableInput decrypt(SeekableInput encryptedInput, KeyMaterial keyMaterial, String algorithm) {
-        return decrypt(encryptedInput, keyMaterial, algorithm, !OPENSSL_IS_AVAILABLE.get());
+        return decrypt(encryptedInput, keyMaterial, algorithm, false);
     }
 
-    @SuppressWarnings("CatchBlockLogException")
     @VisibleForTesting
     static SeekableInput decrypt(
             SeekableInput encryptedInput, KeyMaterial keyMaterial, String algorithm, boolean forceJce) {
-        if (!algorithm.equals(AES_ALGORITHM) || forceJce) {
+        if (!algorithm.equals(AES_ALGORITHM) || !OPENSSL_IS_AVAILABLE.get() || forceJce) {
             return new DecryptingSeekableInput(encryptedInput, SeekableCipherFactory.getCipher(algorithm, keyMaterial));
         }
 
         try {
             return new ApacheCtrDecryptingSeekableInput(encryptedInput, keyMaterial);
         } catch (IOException e) {
-            warningLog(e);
-            return new DecryptingSeekableInput(encryptedInput, SeekableCipherFactory.getCipher(algorithm, keyMaterial));
+            throw new IllegalStateException("Failed to create ApacheCtrDecryptingSeekableInput", e);
         }
     }
 
@@ -96,31 +91,19 @@ public final class CryptoStreamFactory {
      * cipher {@code algorithm}. When OpenSSL is available an implementation that uses AES-NI will be returned.
      */
     public static OutputStream encrypt(OutputStream output, KeyMaterial keyMaterial, String algorithm) {
-        return encrypt(output, keyMaterial, algorithm, !OPENSSL_IS_AVAILABLE.get());
+        return encrypt(output, keyMaterial, algorithm, false);
     }
 
-    @SuppressWarnings("CatchBlockLogException")
     @VisibleForTesting
     static OutputStream encrypt(OutputStream output, KeyMaterial keyMaterial, String algorithm, boolean forceJce) {
-        if (!algorithm.equals(AES_ALGORITHM) || forceJce) {
+        if (!algorithm.equals(AES_ALGORITHM) || !OPENSSL_IS_AVAILABLE.get() || forceJce) {
             return createDefaultEncryptedStream(output, keyMaterial, algorithm);
         }
 
         try {
             return createApacheEncryptedStream(output, keyMaterial);
         } catch (IOException e) {
-            warningLog(e);
-            return createDefaultEncryptedStream(output, keyMaterial, algorithm);
-        }
-    }
-
-    /** To avoid spamming logs with exceptions, we only log the exception once. */
-    private static void warningLog(IOException exception) {
-        if (fullExceptionLoggedAlready) {
-            log.warn(OPEN_SSL_INIT_WARNING);
-        } else {
-            log.warn(OPEN_SSL_INIT_WARNING, exception);
-            fullExceptionLoggedAlready = true;
+            throw new IllegalStateException("Failed to create CtrCryptoOutputStream", e);
         }
     }
 


### PR DESCRIPTION
Logging occurs once, the first time an exception is hit. The
message and stack trace are logged at `INFO` level, and
functionality continues as expected.

==COMMIT_MSG==
CryptoStreamFactory logs reasonably when OpenSSL is or isn't detected
==COMMIT_MSG==

