### PR TITLE
Circle uses java-library-oss template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,94 +2,175 @@
 # To request a modification to the general template, file an issue on Excavator.
 # To manually manage the CircleCI configuration for this project, remove the .circleci/template.sh file.
 
-version: 2
+version: 2.1
 jobs:
-
   compile:
-    docker: [{ image: 'ellisjoe/openjdk-java-openssl:java-8' }]
-    resource_class: xlarge
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    resource_class: large
     environment:
-      GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
-
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=2
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
       - checkout
-      - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --no-daemon --parallel --continue classes testClasses
+      - run:
+          name: delete_unrelated_tags
+          command: |
+            ALL_TAGS=$(git tag --points-at HEAD)
+
+            if [ -z "$ALL_TAGS" ]; then
+                echo "No-op as there are no tags on the current commit ($(git rev-parse HEAD))"
+                exit 0
+            fi
+
+            if [ -z "${CIRCLE_TAG:+x}" ]; then
+                echo "Non-tag build, deleting all tags which point to HEAD: [${ALL_TAGS/$'\n'/,}]"
+                echo "$ALL_TAGS" | while read -r TAG; do git tag -d "$TAG" 1>/dev/null; done
+                exit 0
+            fi
+
+            TAGS_TO_DELETE=$(echo "$ALL_TAGS" | grep -v "^$CIRCLE_TAG$" || :)
+            if [ -z "$TAGS_TO_DELETE" ]; then
+                echo "No-op as exactly one tag ($CIRCLE_TAG) points to HEAD"
+                exit 0
+            fi
+
+            echo "Detected tag build, deleting all tags except '$CIRCLE_TAG' which point to HEAD: [${TAGS_TO_DELETE/$'\n'/,}]"
+            echo "$TAGS_TO_DELETE" | while read -r TAG; do git tag -d "$TAG" 1>/dev/null; done
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'compile-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --parallel --stacktrace classes testClasses
       - save_cache:
-          key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+          key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}'
           paths: [ ~/.gradle/wrapper ]
       - save_cache:
-          key: gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}
+          key: 'compile-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
           paths: [ ~/.gradle/caches ]
+      - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
+      - persist_to_workspace:
+          root: /home/circleci
+          paths: [ project, .gradle/init.gradle ]
 
-  build:
-    docker: [{ image: 'ellisjoe/openjdk-java-openssl:java-8' }]
-    resource_class: xlarge
+  check:
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    resource_class: medium
     environment:
-      GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
-
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=1
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=2 -XX:MaxRAM=4g -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
-      - checkout
-      - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --no-daemon --parallel --continue build
+      - attach_workspace: { at: /home/circleci }
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'check-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --parallel --stacktrace --continue check idea -x test
+      - save_cache:
+          key: 'check-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
       - run:
           command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
           when: always
       - store_test_results: { path: ~/junit }
-      - store_artifacts: { path: ~/poms }
+      - store_artifacts: { path: ~/artifacts }
 
-  build-ibm:
-    docker: [{ image: 'ellisjoe/ibm-java-openssl:java-8' }]
-    resource_class: xlarge
+  unit-test:
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    resource_class: large
     environment:
-      GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
-
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=2
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -XX:MaxRAM=8g -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
     steps:
-      - checkout
-      - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --no-daemon --parallel --continue crypto-core:test
+      - attach_workspace: { at: /home/circleci }
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'unit-test-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --parallel --stacktrace --continue --max-workers=2 test
+      - save_cache:
+          key: 'unit-test-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
       - run:
           command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
           when: always
       - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
+
+  trial-publish:
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    resource_class: medium
+    environment:
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=1
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=2 -XX:MaxRAM=4g -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+    steps:
+      - attach_workspace: { at: /home/circleci }
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'trial-publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run: ./gradlew --stacktrace publishToMavenLocal
+      - run:
+          command: git status --porcelain
+          when: always
+      - save_cache:
+          key: 'trial-publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
+      - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
 
   publish:
-    docker: [{ image: 'ellisjoe/openjdk-java-openssl:java-8' }]
-    resource_class: xlarge
+    docker: [{ image: 'cimg/openjdk:11.0.10-node' }]
+    resource_class: medium
     environment:
-      GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
+      CIRCLE_TEST_REPORTS: /home/circleci/junit
+      CIRCLE_ARTIFACTS: /home/circleci/artifacts
+      GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx2g' -Dorg.gradle.workers.max=1
+      _JAVA_OPTIONS: -XX:ActiveProcessorCount=2 -XX:MaxRAM=4g -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
+    steps:
+      - attach_workspace: { at: /home/circleci }
+      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
+      - restore_cache: { key: 'publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - deploy:
+          command: ./gradlew --parallel --stacktrace --continue publish
+      - run:
+          command: git status --porcelain
+          when: always
+      - save_cache:
+          key: 'publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
+          paths: [ ~/.gradle/caches ]
+      - store_test_results: { path: ~/junit }
+      - store_artifacts: { path: ~/artifacts }
 
+  markdown:
+    docker: [{ image: 'raviqqe/liche:0.1.1' }]
     steps:
       - checkout
-      - restore_cache: { key: 'gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'gradle-cache-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - deploy:
-          command: |
-            # publishing snapshots to bintray does not work, so we only publish from tag builds (not develop)
-            if [[ "${CIRCLE_TAG}" =~ [0-9]+(\.[0-9]+)+(-[a-zA-Z]+[0-9]*)* ]]; then
-              ./gradlew --no-daemon --stacktrace --continue publish
-            else
-              ./gradlew --no-daemon --parallel --continue publishToMavenLocal
-              mkdir -p ~/poms
-              find . -name 'pom-default.xml' -exec cp --parents {} ~/poms \;
-            fi
+      - run: /liche -d . -r . -v
+
 
 workflows:
   version: 2
   build:
     jobs:
       - compile:
-          # CircleCI2 will ignore tags without this. https://circleci.com/docs/2.0/workflows/#git-tag-job-execution
           filters: { tags: { only: /.*/ } }
-      - build:
+
+      - unit-test:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
-      - build-ibm:
+
+      - check:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
+
+      - markdown:
+          filters: { tags: { only: /.*/ } }
+
+      - trial-publish:
+          requires: [ compile ]
+          filters: { branches: { ignore: develop } }
+
       - publish:
-          requires: [ build, build-ibm ]
-          filters: { tags: { only: /.*/ } }
+          requires: [ unit-test, check, trial-publish ]
+          filters: { tags: { only: /.*/ }, branches: { only: develop } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,14 @@ jobs:
       - attach_workspace: { at: /home/circleci }
       - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'unit-test-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
+      - run:
+          name: link_openssl
+          command: |
+            sudo apt-get update -q && sudo apt-get install -qy libssl-dev
+            sudo ln -s /lib/x86_64-linux-gnu/libcrypt.so /usr/lib/libcrypto.so
+            sudo ln -s /lib/x86_64-linux-gnu/libcrypt.so /usr/lib64/libcrypto.so
+            echo "Linked openssl /usr/lib/libcrypto.so"
+            ls -al /lib/libcrypto* /usr/lib/libcrypto* /usr/lib64/libcrypto* /usr/lib/x86_64-linux-gnu/libcrypto*
       - run: ./gradlew --parallel --stacktrace --continue --max-workers=2 test
       - save_cache:
           key: 'unit-test-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export CIRCLECI_TEMPLATE=java-library-oss
+export JDK=11

--- a/.circleci/template.sh
+++ b/.circleci/template.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 export CIRCLECI_TEMPLATE=java-library-oss
 export JDK=11
+export LINK_OPENSSL=true

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ openssl pkcs8 -topk8 -inform pem -in rsa.key -outform pem -nocrypt | grep -v PRI
 Programatic Example
 -------------------
 
-Source for examples can be found [here](hadoop-crypto/src/test/java/com/palantir/hadoop/example/ExampleUsage.java)
+Source for examples can be found [here](hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/example/ExampleUsage.java)
 
 ### Initialization
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Circle CI config was unmanaged, blocking many excavators using JDK 11+ gradle plugins

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Circle uses java-library-oss template
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

