### PR TITLE
[2.x Backport] PathConvertingFileSystem converts FileStatus objects in-place

### DIFF
--- a/changelog/@unreleased/pr-638.v2.yml
+++ b/changelog/@unreleased/pr-638.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: PathConvertingFileSystem renames paths without creating new FileStatus
+    objects.
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/638

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
@@ -139,20 +139,9 @@ public final class PathConvertingFileSystem extends DelegatingFileSystem {
         return fromFunc.apply(path);
     }
 
-    private FileStatus toReturnFileStatus(FileStatus status) throws IOException {
-        // same as FileStatus copy constructor
-        return new FileStatus(
-                status.getLen(),
-                status.isDirectory(),
-                status.getReplication(),
-                status.getBlockSize(),
-                status.getModificationTime(),
-                status.getAccessTime(),
-                status.getPermission(),
-                status.getOwner(),
-                status.getGroup(),
-                status.isSymlink() ? status.getSymlink() : null, // getSymlink throws if file is not a symlink
-                from(status.getPath()));
+    private FileStatus toReturnFileStatus(FileStatus status) {
+        status.setPath(from(status.getPath()));
+        return status;
     }
 
 }

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
@@ -123,10 +123,8 @@ public final class PathConvertingFileSystemTest {
         when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] {delegateFileStatus});
         FileStatus[] fileStatuses = convertingFs.listStatus(PATH);
 
-        assertThat(fileStatuses)
-                .satisfiesExactly(status ->
-                        // The returned status is the same object returned by the delegate, the path converted in-place
-                        assertThat(status).isEqualTo(fileStatus(RETURN_PATH)).isSameAs(delegateFileStatus));
+        assertThat(fileStatuses).containsExactly(fileStatus(RETURN_PATH));
+        assertThat(fileStatus(RETURN_PATH)).isEqualTo(delegateFileStatus);
     }
 
     @Test

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/PathConvertingFileSystemTest.java
@@ -119,18 +119,24 @@ public final class PathConvertingFileSystemTest {
 
     @Test
     public void listStatus() throws Exception {
-        when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] {fileStatus(DELEGATE_PATH)});
+        FileStatus delegateFileStatus = fileStatus(DELEGATE_PATH);
+        when(delegate.listStatus(DELEGATE_PATH)).thenReturn(new FileStatus[] {delegateFileStatus});
         FileStatus[] fileStatuses = convertingFs.listStatus(PATH);
 
-        assertThat(fileStatuses).containsExactly(fileStatus(RETURN_PATH));
+        assertThat(fileStatuses)
+                .satisfiesExactly(status ->
+                        // The returned status is the same object returned by the delegate, the path converted in-place
+                        assertThat(status).isEqualTo(fileStatus(RETURN_PATH)).isSameAs(delegateFileStatus));
     }
 
     @Test
     public void getFileStatus() throws Exception {
-        when(delegate.getFileStatus(DELEGATE_PATH)).thenReturn(fileStatus(DELEGATE_PATH));
-        FileStatus fileStatus = convertingFs.getFileStatus(PATH);
+        FileStatus delegateFileStatus = fileStatus(DELEGATE_PATH);
+        when(delegate.getFileStatus(DELEGATE_PATH)).thenReturn(delegateFileStatus);
+        FileStatus convertedFileStatus = convertingFs.getFileStatus(PATH);
 
-        assertThat(fileStatus).isEqualTo(fileStatus(RETURN_PATH));
+        // The returned status is the same object returned by the delegate, the path converted in-place
+        assertThat(convertedFileStatus).isEqualTo(fileStatus(RETURN_PATH)).isSameAs(delegateFileStatus);
     }
 
     @Test


### PR DESCRIPTION
Backport of #638 on 2.x

* PathConvertingFileSystem renames paths without creating new FileStatus objects

* Add generated changelog entries

* Reflect updated FileStatus conversion in test

Co-authored-by: svc-changelog <svc-changelog@palantir.com>

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
PathConvertingFileSystem converts FileStatus objects in-place
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

