### PR TITLE
Do not set scheme if unset

### DIFF
--- a/changelog/@unreleased/pr-667.v2.yml
+++ b/changelog/@unreleased/pr-667.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: StandaloneEncryptedFileSystem returns to its old behavior, of only
+    overriding the scheme when the uri uses a scheme
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/667

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
@@ -16,6 +16,7 @@
 
 package com.palantir.crypto2.hadoop;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
@@ -146,7 +147,8 @@ public final class PathConvertingFileSystem extends DelegatingFileSystem {
         return fs.getFileChecksum(to(path));
     }
 
-    private Path to(Path path) {
+    @VisibleForTesting
+    Path to(Path path) {
         return toFunc.apply(path);
     }
 

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystem.java
@@ -164,6 +164,9 @@ public final class StandaloneEncryptedFileSystem extends FilterFileSystem {
 
     private static Function<URI, URI> setUriSchemeFunc(final String scheme) {
         return uri -> {
+            if (uri.getScheme() == null) {
+                return uri;
+            }
             try {
                 return new URI(
                         scheme,

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/StandaloneEncryptedFileSystemTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyPair;
@@ -36,7 +35,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -299,94 +297,22 @@ public final class StandaloneEncryptedFileSystemTest {
     }
 
     /**
-     * This validation logic for {@link S3MimicingFileSystem#checkPath} is copied exactly from
-     * {@link org.apache.hadoop.fs.s3a.S3AFileSystem} and {@link org.apache.hadoop.fs.s3native.S3xLoginHelper}.
+     * Preserving paths with no scheme present is helpful to bypass validation in
+     * {@link org.apache.hadoop.fs.s3native.S3xLoginHelper#checkPath} when using S3A.
      */
-    static class S3MimicingFileSystem extends DelegatingFileSystem {
-        protected S3MimicingFileSystem(FileSystem delegate) {
-            super(delegate);
-        }
-
-        @Override
-        public void checkPath(Path path) {
-            checkPath(getConf(), getUri(), path, getDefaultPort());
-            super.checkPath(path);
-        }
-
-        @SuppressWarnings({"ReferenceEquality", "OperatorPrecedence"})
-        private void checkPath(Configuration conf, URI fsUri, Path path, int defaultPort) {
-            URI pathUri = path.toUri();
-            String thatScheme = pathUri.getScheme();
-            if (thatScheme != null) {
-                URI thisUri = canonicalizeUri(fsUri, defaultPort);
-                String thisScheme = thisUri.getScheme();
-                if (StringUtils.equalsIgnoreCase(thisScheme, thatScheme)) {
-                    String thisHost = thisUri.getHost();
-                    String thatHost = pathUri.getHost();
-                    if (thatHost == null && thisHost != null) {
-                        URI defaultUri = FileSystem.getDefaultUri(conf);
-                        if (StringUtils.equalsIgnoreCase(thisScheme, defaultUri.getScheme())) {
-                            pathUri = defaultUri;
-                        } else {
-                            pathUri = null;
-                        }
-                    }
-
-                    if (pathUri != null) {
-                        pathUri = canonicalizeUri(pathUri, defaultPort);
-                        thatHost = pathUri.getHost();
-                        if (thisHost == thatHost
-                                || thisHost != null && StringUtils.equalsIgnoreCase(thisHost, thatHost)) {
-                            return;
-                        }
-                    }
-                }
-
-                throw new IllegalArgumentException("Wrong FS " + toString(pathUri) + " -expected " + fsUri);
-            }
-        }
-
-        @SuppressWarnings("ParameterAssignment")
-        private URI canonicalizeUri(URI uri, int defaultPort) {
-            if (uri.getPort() == -1 && defaultPort > 0) {
-                try {
-                    uri = new URI(
-                            uri.getScheme(),
-                            uri.getUserInfo(),
-                            uri.getHost(),
-                            defaultPort,
-                            uri.getPath(),
-                            uri.getQuery(),
-                            uri.getFragment());
-                } catch (URISyntaxException var3) {
-                    throw new AssertionError("Valid URI became unparseable: " + uri);
-                }
-            }
-
-            return uri;
-        }
-
-        private String toString(URI pathUri) {
-            return pathUri != null
-                    ? String.format("%s://%s/%s", pathUri.getScheme(), pathUri.getHost(), pathUri.getPath())
-                    : "(null URI)";
-        }
-    }
-
     @Test
-    public void testS3WorksWhenNoDefaultFsSet() {
-        S3MimicingFileSystem s3MimicingEfs = new S3MimicingFileSystem(efs);
-
+    public void testNoScheme() {
         // Convert the file path, because that normally happens by the time FileSystem calls checkPath internally
         StandaloneEncryptedFileSystem standaloneEncryptedFileSystem = (StandaloneEncryptedFileSystem) efs;
         EncryptedFileSystem encryptedFileSystem =
                 (EncryptedFileSystem) standaloneEncryptedFileSystem.getRawFileSystem();
         PathConvertingFileSystem pathConvertingFileSystem =
                 (PathConvertingFileSystem) encryptedFileSystem.getRawFileSystem();
-        path = pathConvertingFileSystem.to(path);
+        Path convertedPath = pathConvertingFileSystem.to(path);
 
-        // Actually test that S3's logic to check the path should work. Most methods check this validation first.
-        s3MimicingEfs.checkPath(path);
+        // Just like the original path, the converted path should not have a scheme
+        assertThat(path.toUri().getScheme()).isNull();
+        assertThat(convertedPath.toUri().getScheme()).isNull();
     }
 
     private static Configuration getBaseConf() {


### PR DESCRIPTION
## Before this PR
StandaloneEncryptedFileSystem#setUriSchemeFunc will always set the uri's scheme, even if it's not already set.

## After this PR
We only set the scheme if it's already set. This matches the behavior of this class in 2.9.2: https://github.com/palantir/hadoop-crypto/pull/442/files#diff-050a60db63beecf42d4d99e5e9132ee7f6dc68ae9b552e37ff5ccd2a109806d6L166
==COMMIT_MSG==
StandaloneEncryptedFileSystem returns to its old behavior, of only overriding the scheme when the uri uses a scheme
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

