### PR TITLE
Do not delete keymaterial before file

### DIFF
--- a/changelog/@unreleased/pr-887.v2.yml
+++ b/changelog/@unreleased/pr-887.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix some edge cases that could cause a KeyMaterial to be deleted before
+    the file that it encrypts
+  links:
+  - https://github.com/palantir/hadoop-crypto/pull/887

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
@@ -145,7 +145,7 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
 
         if (renamed) {
             tryRemoveKey(src);
-        } else {
+        } else if (!fs.exists(dst)) {
             tryRemoveKey(dst);
         }
 
@@ -172,9 +172,14 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
             throw new UnsupportedOperationException("EncryptedFileSystem does not support recursive deletes");
         }
 
-        // Interrupted deletes should be resumable. They are expected to be retried.
-        tryRemoveKey(path);
-        return fs.delete(path, false);
+        boolean success = fs.delete(path, false);
+
+        if (success || !fs.exists(path)) {
+            // Interrupted deletes should be resumable. They are expected to be retried.
+            tryRemoveKey(path);
+        }
+
+        return success;
     }
 
     @Override

--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/EncryptedFileSystem.java
@@ -137,6 +137,11 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
 
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
+        // Should not overwrite if a file already exists in the destination
+        if (fs.exists(dst)) {
+            return false;
+        }
+
         // Copy key material first so the encrypted file always has key material in the key store even if the
         // put or rename fails
         KeyMaterial keyMaterial = keyStore.get(src.toString());
@@ -146,6 +151,8 @@ public final class EncryptedFileSystem extends DelegatingFileSystem {
         if (renamed) {
             tryRemoveKey(src);
         } else if (!fs.exists(dst)) {
+            // The reason we check again if the destination exists before removing the key, is because there are edge
+            // cases where FileSystem#rename can create the new file but still claim failure.
             tryRemoveKey(dst);
         }
 

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
@@ -264,6 +264,20 @@ public final class EncryptedFileSystemTest {
         boolean renamed = mockedEfs.rename(path, newPath);
 
         assertThat(renamed).isFalse();
+        verify(mockKeyStore, never()).put(eq(newPath.toString()), any());
+        verify(mockKeyStore, never()).remove(path.toString());
+        verify(mockKeyStore, never()).remove(newPath.toString());
+    }
+
+    @Test
+    public void testRename_failedRenameButDestinationFileExistsAfterCreation() throws IOException {
+        when(mockFs.exists(newPath)).thenReturn(false, true);
+        when(mockFs.rename(path, newPath)).thenReturn(false);
+
+        boolean renamed = mockedEfs.rename(path, newPath);
+
+        assertThat(renamed).isFalse();
+        verify(mockKeyStore).put(eq(newPath.toString()), any());
         verify(mockKeyStore, never()).remove(path.toString());
         verify(mockKeyStore, never()).remove(newPath.toString());
     }

--- a/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
+++ b/hadoop-crypto/src/test/java/com/palantir/crypto2/hadoop/EncryptedFileSystemTest.java
@@ -257,6 +257,18 @@ public final class EncryptedFileSystemTest {
     }
 
     @Test
+    public void testRename_failedRenameBecauseDestinationFileAlreadyExists() throws IOException {
+        when(mockFs.exists(newPath)).thenReturn(true);
+        when(mockFs.rename(path, newPath)).thenReturn(false);
+
+        boolean renamed = mockedEfs.rename(path, newPath);
+
+        assertThat(renamed).isFalse();
+        verify(mockKeyStore, never()).remove(path.toString());
+        verify(mockKeyStore, never()).remove(newPath.toString());
+    }
+
+    @Test
     public void testRename_successfulRenameFailedRemoveIsIgnored() throws IOException {
         when(mockFs.rename(path, newPath)).thenReturn(true);
         doThrow(new IllegalArgumentException()).when(mockKeyStore).remove(anyString());
@@ -371,6 +383,24 @@ public final class EncryptedFileSystemTest {
         assertThat(keyStore.get(path.toString())).isInstanceOf(KeyMaterial.class);
         assertThat(efs.delete(path, false)).isFalse();
         assertThat(keyStore.get(path.toString())).isNull();
+    }
+
+    @Test
+    public void testDelete_deleteFileFailsAndStillExists() throws IOException {
+        when(mockFs.delete(path, false)).thenReturn(false);
+        when(mockFs.exists(path)).thenReturn(true);
+
+        assertThat(mockedEfs.delete(path, false)).isFalse();
+        verify(mockKeyStore, never()).remove(path.toString());
+    }
+
+    @Test
+    public void testDelete_deleteFileFailsAndDoesNotExist() throws IOException {
+        when(mockFs.delete(path, false)).thenReturn(false);
+        when(mockFs.exists(path)).thenReturn(false);
+
+        assertThat(mockedEfs.delete(path, false)).isFalse();
+        verify(mockKeyStore).remove(path.toString());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Two bugs exist in `EncryptedFileSystem` that could cause a `KeyMaterial` to be deleted before the file that it encrypts.

First, if `rename` returns `false` but the destination file still exists, we should never delete the destination's `KeyMaterial`. This could happen when trying to rename a file when the destination file already exists, though that means there's likely a bug with the code that called rename. It could also signify an edge case with the `rename` code itself, e.g. `AzureNativeFileSystemStore#rename` can succeed at renaming the file but still not fully succeed because of an error at the end of the file when calling `AzureNativeFileSystemStore#safeDelete` to try to delete the source file.

Second, `delete` should be the inverse of `create`. When we create a file, we create its `KeyMaterial` before the actual file. Thus, on delete, we should flip that order and delete the file before the `KeyMaterial`. Only if the file actually got deleted should we delete its `KeyMaterial`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix some edge cases that could cause a KeyMaterial to be deleted before the file that it encrypts
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

