### PR TITLE
PathConvertingFileSystem also converts createFile

### DIFF
--- a/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
+++ b/hadoop-crypto/src/main/java/com/palantir/crypto2/hadoop/PathConvertingFileSystem.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSDataOutputStreamBuilder;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -106,6 +107,11 @@ public final class PathConvertingFileSystem extends DelegatingFileSystem {
     @Override
     public boolean delete(Path path, boolean recursive) throws IOException {
         return delegate.delete(to(path), recursive);
+    }
+
+    @Override
+    public FSDataOutputStreamBuilder<?, ?> createFile(Path path) {
+        return delegate.createFile(to(path));
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
`PathConvertingFileSystem` would properly convert the path for files when using all other methods like `create` but not when using `createFile`

## After this PR
Now it converts `createFile` too

==COMMIT_MSG==
PathConvertingFileSystem properly converts calls to createFile
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

